### PR TITLE
Homepage: Drupal block & Gutenberg pop.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=8.1",
         "composer/installers": "^1.9",
+        "cweagans/composer-patches": "^1.7",
         "drupal-tome/tome_drush": "dev-master",
         "drupal/admin_toolbar": "^2.4",
         "drupal/core-composer-scaffold": "^9.0.0",
@@ -43,10 +44,16 @@
         "allow-plugins": {
             "composer/installers": true,
             "drupal/core-composer-scaffold": true,
-            "acquia/blt": true
+            "acquia/blt": true,
+            "cweagans/composer-patches": true
         }
     },
     "extra": {
+        "patches": {
+            "drupal/gutenberg": {
+                "Welcome to Gutenberg editor popup appears for anonymous user": "https://www.drupal.org/files/issues/2022-10-05/3310913-9.patch"
+            }
+        },
         "drupal-scaffold": {
             "locations": {
                 "web-root": "docroot/"
@@ -70,12 +77,6 @@
             ],
             "drush/Commands/contrib/{$name}": [
                 "type:drupal-drush"
-            ],
-            "docroot/modules/custom/{$name}": [
-                "type:drupal-custom-module"
-            ],
-            "docroot/themes/custom/{$name}": [
-                "type:drupal-custom-theme"
             ]
         }
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7563621ec57fe219efb81d1a2d35e90f",
+    "content-hash": "ff37bc922d14daa9c7458efcff8dec25",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -902,6 +902,54 @@
                 "source": "https://github.com/consolidation/site-process/tree/4.2.1"
             },
             "time": "2022-10-18T13:19:35+00:00"
+        },
+        {
+            "name": "cweagans/composer-patches",
+            "version": "1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cweagans/composer-patches.git",
+                "reference": "e9969cfc0796e6dea9b4e52f77f18e1065212871"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cweagans/composer-patches/zipball/e9969cfc0796e6dea9b4e52f77f18e1065212871",
+                "reference": "e9969cfc0796e6dea9b4e52f77f18e1065212871",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0 || ~2.0",
+                "phpunit/phpunit": "~4.6"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "cweagans\\Composer\\Patches"
+            },
+            "autoload": {
+                "psr-4": {
+                    "cweagans\\Composer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Cameron Eagans",
+                    "email": "me@cweagans.net"
+                }
+            ],
+            "description": "Provides a way to patch Composer packages.",
+            "support": {
+                "issues": "https://github.com/cweagans/composer-patches/issues",
+                "source": "https://github.com/cweagans/composer-patches/tree/1.7.2"
+            },
+            "time": "2022-01-25T19:21:20+00:00"
         },
         {
             "name": "dflydev/dot-access-data",

--- a/config/default/block.block.olivero_powered.yml
+++ b/config/default/block.block.olivero_powered.yml
@@ -1,6 +1,6 @@
 uuid: 1d710569-d4e9-4fd5-b3ab-60185aef26e1
 langcode: en
-status: true
+status: false
 dependencies:
   module:
     - system

--- a/config/default/core.entity_form_display.node.blog.default.yml
+++ b/config/default/core.entity_form_display.node.blog.default.yml
@@ -36,6 +36,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   promote:
     type: boolean_checkbox
     weight: 15


### PR DESCRIPTION
- Pulls in a patch for Gutenberg to not show the editor tour on the site homepage.
- Removes the "Powered by Drupal" block (disables it for now).
- Updates a config setting via `$ drush config:export`.