### PR TITLE
Add Disqus to project (SEO addressed).

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "extra": {
         "patches": {
             "drupal/disqus": {
-                "Lazy load / async load Disqus libraries for better performance": "https://www.drupal.org/files/issues/2022-10-20/disqus-1508786-lazyload-intersectionobserver-47-1.x.patch"
+                "Lazy load / async load Disqus libraries for better performance": "https://www.drupal.org/files/issues/2022-10-19/disqus-1508786-lazyload-intersectionobserver-46-2.0.x.patch"
             },
             "drupal/core": {
                 "Lighthouse SEO: Uncrawlable Link a#main-content": "patches/3222236.patch"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/coder": "^8.3",
         "drupal/core-composer-scaffold": "^9.0.0",
         "drupal/core-recommended": "^9.0.0",
+        "drupal/disqus": "^2.0",
         "drupal/google_analytics": "^4.0",
         "drupal/gutenberg": "^2.5",
         "drupal/honeypot": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
     },
     "extra": {
         "patches": {
+            "drupal/disqus": {
+                "Lazy load / async load Disqus libraries for better performance": "https://www.drupal.org/files/issues/2022-10-20/disqus-1508786-lazyload-intersectionobserver-47-1.x.patch"
+            },
             "drupal/core": {
                 "Lighthouse SEO: Uncrawlable Link a#main-content": "patches/3222236.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "34b7b074ba4624782c4c8643e854164b",
+    "content-hash": "a378d6798537c3037e00c214590c048f",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a378d6798537c3037e00c214590c048f",
+    "content-hash": "68c57cddd4bd790451a040c441346a39",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1509,7 +1509,7 @@
             "extra": {
                 "drupal": {
                     "version": "5.0.0",
-                    "datestamp": "1658178949",
+                    "datestamp": "1672697815",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "22b2e2c7097cee4fe0428069e0b191fa",
+    "content-hash": "34b7b074ba4624782c4c8643e854164b",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1102,6 +1102,51 @@
             "time": "2022-10-27T11:44:00+00:00"
         },
         {
+            "name": "disqus/disqus-php",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RobLoach/disqus-php.git",
+                "reference": "68bf75139c0bc0c40dd5a2fbf28fe9e326a32001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RobLoach/disqus-php/zipball/68bf75139c0bc0c40dd5a2fbf28fe9e326a32001",
+                "reference": "68bf75139c0bc0c40dd5a2fbf28fe9e326a32001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "replace": {
+                "drexarj/disqus-php": "*",
+                "jakubzapletal/disqus-php": "*",
+                "jasonrgd/disqus-php": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "disqusapi/"
+                ],
+                "exclude-from-classmap": [
+                    "/disqusapi/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Disqus API bindings for PHP",
+            "homepage": "https://github.com/RobLoach/disqus-php",
+            "support": {
+                "source": "https://github.com/RobLoach/disqus-php/tree/1.0.2"
+            },
+            "time": "2019-07-24T04:13:30+00:00"
+        },
+        {
             "name": "doctrine/annotations",
             "version": "1.13.3",
             "source": {
@@ -1961,6 +2006,83 @@
             "support": {
                 "source": "https://git.drupalcode.org/project/ctools",
                 "issues": "https://www.drupal.org/project/issues/ctools"
+            }
+        },
+        {
+            "name": "drupal/disqus",
+            "version": "2.0.1-alpha5",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/disqus.git",
+                "reference": "2.0.1-alpha5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/disqus-2.0.1-alpha5.zip",
+                "reference": "2.0.1-alpha5",
+                "shasum": "cc7c261dadf0afedb164804c1f5dad79155271e7"
+            },
+            "require": {
+                "disqus/disqus-php": "^1.0",
+                "drupal/core": "^8.8 || ^9"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.1-alpha5",
+                    "datestamp": "1643698349",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "DamienMcKenna",
+                    "homepage": "https://www.drupal.org/user/108450"
+                },
+                {
+                    "name": "JayeshSolanki",
+                    "homepage": "https://www.drupal.org/user/2832795"
+                },
+                {
+                    "name": "RobLoach",
+                    "homepage": "https://www.drupal.org/user/61114"
+                },
+                {
+                    "name": "bkosborne",
+                    "homepage": "https://www.drupal.org/user/788032"
+                },
+                {
+                    "name": "dawehner",
+                    "homepage": "https://www.drupal.org/user/99340"
+                },
+                {
+                    "name": "gaurav.kapoor",
+                    "homepage": "https://www.drupal.org/user/3495331"
+                },
+                {
+                    "name": "jason.blanda",
+                    "homepage": "https://www.drupal.org/user/1969424"
+                },
+                {
+                    "name": "marcingy",
+                    "homepage": "https://www.drupal.org/user/77320"
+                },
+                {
+                    "name": "slashrsm",
+                    "homepage": "https://www.drupal.org/user/744628"
+                }
+            ],
+            "description": "Disqus module for Drupal.",
+            "homepage": "http://drupal.org/project/disqus",
+            "support": {
+                "source": "https://git.drupalcode.org/project/disqus"
             }
         },
         {

--- a/config/default/core.entity_form_display.node.blog.default.yml
+++ b/config/default/core.entity_form_display.node.blog.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.node.blog.body
+    - field.field.node.blog.field_comments
     - field.field.node.blog.field_post_date
     - field.field.node.blog.field_tags
     - node.type.blog
   module:
     - datetime
+    - disqus
     - path
     - text
 id: node.blog.default
@@ -18,7 +20,7 @@ mode: default
 content:
   body:
     type: text_textarea_with_summary
-    weight: 121
+    weight: 7
     region: content
     settings:
       rows: 9
@@ -28,19 +30,25 @@ content:
     third_party_settings: {  }
   created:
     type: datetime_timestamp
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_comments:
+    type: disqus_comment
     weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   field_post_date:
     type: datetime_default
-    weight: 122
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete_tags
-    weight: 123
+    weight: 9
     region: content
     settings:
       match_operator: CONTAINS
@@ -50,34 +58,34 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 30
+    weight: 5
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 15
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 120
+    weight: 6
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 16
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: -5
+    weight: 0
     region: content
     settings:
       size: 60
@@ -85,7 +93,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 1
     region: content
     settings:
       match_operator: CONTAINS

--- a/config/default/core.entity_view_display.node.blog.default.yml
+++ b/config/default/core.entity_view_display.node.blog.default.yml
@@ -4,11 +4,13 @@ status: true
 dependencies:
   config:
     - field.field.node.blog.body
+    - field.field.node.blog.field_comments
     - field.field.node.blog.field_post_date
     - field.field.node.blog.field_tags
     - node.type.blog
   module:
     - datetime
+    - disqus
     - text
     - user
 id: node.blog.default
@@ -22,6 +24,13 @@ content:
     settings: {  }
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_comments:
+    type: disqus_comment
+    label: visually_hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_post_date:
     type: datetime_default

--- a/config/default/core.entity_view_display.node.blog.teaser.yml
+++ b/config/default/core.entity_view_display.node.blog.teaser.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.blog.body
+    - field.field.node.blog.field_comments
     - field.field.node.blog.field_post_date
     - field.field.node.blog.field_tags
     - node.type.blog
@@ -30,5 +31,6 @@ content:
     weight: 100
     region: content
 hidden:
+  field_comments: true
   field_post_date: true
   field_tags: true

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -9,6 +9,7 @@ module:
   breakpoint: 0
   datetime: 0
   dblog: 0
+  disqus: 0
   dynamic_page_cache: 0
   editor: 0
   field: 0

--- a/config/default/disqus.settings.yml
+++ b/config/default/disqus.settings.yml
@@ -1,0 +1,19 @@
+_core:
+  default_config_hash: Llro1YlSl1oOAdzusK0r0JeD5CzYhWuW5KTPM3UHmT8
+disqus_domain: davidpagini
+behavior:
+  disqus_localization: false
+  disqus_inherit_login: false
+  disqus_track_newcomment_ga: true
+  disqus_notify_newcomment: false
+advanced:
+  disqus_useraccesstoken: ''
+  disqus_publickey: ''
+  disqus_secretkey: ''
+  api:
+    disqus_api_update: false
+    disqus_api_delete: '0'
+  sso:
+    disqus_sso: false
+    disqus_use_site_logo: false
+    disqus_logo: ''

--- a/config/default/field.field.node.blog.field_comments.yml
+++ b/config/default/field.field.node.blog.field_comments.yml
@@ -1,0 +1,24 @@
+uuid: 9a369bff-c9ff-43fa-9250-6525730e5b03
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_comments
+    - node.type.blog
+  module:
+    - disqus
+id: node.blog.field_comments
+field_name: field_comments
+entity_type: node
+bundle: blog
+label: Comments
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    status: false
+    identifier: ''
+default_value_callback: ''
+settings: {  }
+field_type: disqus_comment

--- a/config/default/field.storage.node.field_comments.yml
+++ b/config/default/field.storage.node.field_comments.yml
@@ -1,0 +1,19 @@
+uuid: 3a92f703-3455-476d-8f23-fda8acb3524d
+langcode: en
+status: true
+dependencies:
+  module:
+    - disqus
+    - node
+id: node.field_comments
+field_name: field_comments
+entity_type: node
+type: disqus_comment
+settings: {  }
+module: disqus
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/default/user.role.anonymous.yml
+++ b/config/default/user.role.anonymous.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   module:
+    - disqus
     - system
 _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
@@ -12,3 +13,4 @@ weight: 0
 is_admin: false
 permissions:
   - 'access content'
+  - 'view disqus comments'

--- a/content/node.6c3579c8-d598-4c73-a30a-e7b1edd7ff30.json
+++ b/content/node.6c3579c8-d598-4c73-a30a-e7b1edd7ff30.json
@@ -18,7 +18,7 @@
     ],
     "revision_timestamp": [
         {
-            "value": "2022-12-19T03:35:12+00:00",
+            "value": "2022-12-19T03:58:53+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -53,7 +53,7 @@
     ],
     "changed": [
         {
-            "value": "2022-12-19T03:35:12+00:00",
+            "value": "2022-12-19T03:58:53+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -89,6 +89,12 @@
             "value": "<!-- wp:paragraph -->\r\n<p>My site is <em>finally<\/em> live. After <strong>years<\/strong> of procrastinating putting up a web presence (<em>even though I'm a web developer<\/em>), I finally got around to publishing a website.<\/p>\r\n<!-- \/wp:paragraph -->\r\n\r\n<!-- wp:code -->\r\n<pre class=\"wp-block-code\"><code>console.log('Hello world!');<\/code><\/pre>\r\n<!-- \/wp:code -->\r\n\r\n<!-- wp:paragraph -->\r\n<p>Naturally, my first post will be to tell you what I did...<\/p>\r\n<!-- \/wp:paragraph -->\r\n\r\n<!-- wp:heading -->\r\n<h2 id=\"tries\">A history of tries<\/h2>\r\n<!-- \/wp:heading -->\r\n\r\n<!-- wp:paragraph -->\r\n<p>In my perfect world, I would put my 10+ years of Drupal experience to work, build a perfect DevOps pipeline, and push directly to production on a Kubernetes cluster running on a cost-effective AWS\/GCP\/Azure infrastructure. I've always been a bit cost conscience... I've considered trying to <em>roll your own<\/em> server with EC2 instances, or the $5\/mo. Amazon LightSail option. But the combination of the cost, and being overly-complicated, these factors always kept me from really pursuing this option.<\/p>\r\n<!-- \/wp:paragraph -->\r\n\r\n<!-- wp:paragraph -->\r\n<p>I've been using Github Pages for quite a few years now, taking advantage of publishing static (small) websites for free on the Github platform. The idea of using GH pages to host davidpagini.com has been a passing thought for years, I just wanted to be sure it was scalable. I've explored Jekyll and javascript libraries, but never found something I was convinced would be successful, until...<\/p>\r\n<!-- \/wp:paragraph -->\r\n\r\n<!-- wp:heading -->\r\n<h2 id=\"drupal\">Dance with the one who brought you<\/h2>\r\n<!-- \/wp:heading -->\r\n\r\n<!-- wp:paragraph -->\r\n<p>As previously mentioned, Drupal was always going to be a bit overkill for a simple site like this. It offers <em>amazing<\/em> content management, a library of pre-built functionality (modules), accessibility and responsiveness handled for you, and plenty more features. But then I learned about a module called <a rel=\"noreferrer noopener\" href=\"https:\/\/drupal.org\/project\/tome\" target=\"_blank\">Tome<\/a>, which allows a user to build their site in Drupal, and then export it to a static site, which could be easily hosted directly on Github.com.<\/p>\r\n<!-- \/wp:paragraph -->\r\n\r\n<!-- wp:paragraph -->\r\n<p>For the last piece of my puzzle, I was in search of a fast and lightweight local environment, which would essentially function as \"production\" for me, that could be simply plugged into a DevOps pipeline, likely to be Github Actions. I was hearing increasingly more about <a rel=\"noreferrer noopener\" href=\"https:\/\/lando.dev\" target=\"_blank\">Lando<\/a>, growing every year in popularity, and we just decided to adopt the tool at work. I've had the pleasure of working with Mike (<a rel=\"noreferrer noopener\" href=\"https:\/\/github.com\/pirog\" target=\"_blank\">@pirog<\/a>) and Alec (<a rel=\"noreferrer noopener\" href=\"https:\/\/github.com\/reynoldsalec\" target=\"_blank\">@reynoldsalec<\/a>) from the Lando team, and finally gave the tool a try. <\/p>\r\n<!-- \/wp:paragraph -->\r\n\r\n<!-- wp:paragraph -->\r\n<p>So I'm going with Drupal, Tome, Lando, Github, and a suite of other tools to bring this site to life. I intend on writing about this journey further in the near future, but so far I'm very pleased with ease of standing up a site I can be proud of...<\/p>\r\n<!-- \/wp:paragraph -->",
             "format": "gutenberg",
             "summary": "Using Github pages, Drupal, Lando and Tome to bring together a live static site implementation of DavidPagini.com."
+        }
+    ],
+    "field_comments": [
+        {
+            "status": 1,
+            "identifier": ""
         }
     ],
     "field_post_date": [

--- a/docroot/ads.txt
+++ b/docroot/ads.txt
@@ -1,0 +1,56 @@
+disqus.com, 4813341, DIRECT
+google.com, pub-6650322601660058, RESELLER, f08c47fec0942fa0
+aax.media, AAXN9V74H, DIRECT
+media.net, 8PR6YK195, RESELLER
+pubmatic.com, 158984, RESELLER, 5d62403b186f2ace
+indexexchange.com, 192393, RESELLER
+rubiconproject.com, 23280, RESELLER, 0bfd66d529a55807
+openx.com, 543731411, RESELLER, 6a698e2ec38604c6
+appnexus.com, 3153, RESELLER, f5ab79cb980f11d1
+adagio.io, 1239, DIRECT
+rubiconproject.com, 19116, RESELLER, 0bfd66d529a55807
+pubmatic.com, 159110, RESELLER, 5d62403b186f2ace
+indexexchange.com, 194558, RESELLER
+amxrtb.com, 105199574, DIRECT
+appnexus.com, 12290, RESELLER
+indexexchange.com, 191503, RESELLER, 50b1c356f2c5c8fc
+pubmatic.com, 158355, RESELLER, 5d62403b186f2ace
+lijit.com, 260380, RESELLER, fafdf38b16bf6b2b
+sovrn.com, 260380, RESELLER, fafdf38b16bf6b2b
+adyoulike.com, 65821909b0ce70f6e87747d8f22c3cf0, DIRECT
+appnexus.com, 9733, RESELLER
+spotxchange.com, 230037, RESELLER, 7842df1d2fe2db34
+spotx.tv, 230037, RESELLER, 7842df1d2fe2db34
+rubiconproject.com, 20736, RESELLER, 0bfd66d529a55807
+aps.amazon.com,31d3a4c9-a8a6-4ae0-a5ae-d3b0de43284c,DIRECT
+pubmatic.com,157150,RESELLER,5d62403b186f2ace
+pubmatic.com,160006,RESELLER,5d62403b186f2ace
+pubmatic.com,160096,RESELLER,5d62403b186f2ace
+sharethrough.com,7144eb80,RESELLER,d53b998a7bd4ecd2
+smartadserver.com,4125,RESELLER,060d053dcf45cbf3
+aniview.com, 616704c962b31624e671e171, RESELLER, 78b21b97965ec3f8
+advertising.com, 23089, RESELLER
+appnexus.com, 12637, RESELLER, f5ab79cb980f11d1
+google.com, pub-3565385483761681, DIRECT, f08c47fec0942fa0
+pubmatic.com, 161335, RESELLER, 5d62403b186f2ace
+rubiconproject.com, 13918, RESELLER, 0bfd66d529a55807
+criteo.com, B-060574, DIRECT, 9fac4a4a87c2a44f
+themediagrid.com, T49HZW, DIRECT, 35d5010d7789b49d
+rubiconproject.com, 13380, RESELLER, 0bfd66d529a55807
+onetag.com, 5cd7fb62fac7ec9, DIRECT
+openx.com, 537133236, RESELLER, 6a698e2ec38604c6
+pubmatic.com, 158685, RESELLER, 5d62403b186f2ace
+sharethrough.com, vqSnJqKh, DIRECT, d53b998a7bd4ecd2
+sonobi.com, 296bf9795d, DIRECT, d1a215d9eb5aee9e
+sonobi.com, 05fbc758ee, DIRECT, d1a215d9eb5aee9e
+contextweb.com, 560606, RESELLER, 89ff185a4c4e857c
+sovrn.com, 279534, DIRECT, fafdf38b16bf6b2b
+lijit.com, 279534, DIRECT, fafdf38b16bf6b2b
+appnexus.com, 2797, DIRECT
+yahoo.com, 56704, DIRECT
+taboola.com,1003147,DIRECT,c228e6794e811952
+spotx.tv,71451,RESELLER
+advertising.com, 8603, RESELLER
+contextweb.com, 560382, RESELLER
+openx.com, 539154393, RESELLER
+rubiconproject.com, 16698, RESELLER, 0bfd66d529a55807


### PR DESCRIPTION
Originally added in #29.

* Adds `drupal/disqus` to the site.
* Adds a comments field to the blog content type.
* Configures Disqus for `davidpagini`.
* Adds `/ads.txt` file.
  * _Need to figure out how to export this to static site._
* 🆕 Uses patch to load Disqus so it performs well in Lighthouse scores.