### PR TITLE
Tome static generator to include font files.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,14 +54,17 @@
     },
     "extra": {
         "patches": {
-            "drupal/disqus": {
-                "Lazy load / async load Disqus libraries for better performance": "https://www.drupal.org/files/issues/2022-10-19/disqus-1508786-lazyload-intersectionobserver-46-2.0.x.patch"
-            },
             "drupal/core": {
                 "Lighthouse SEO: Uncrawlable Link a#main-content": "patches/3222236.patch"
             },
+            "drupal/disqus": {
+                "Lazy load / async load Disqus libraries for better performance": "https://www.drupal.org/files/issues/2022-10-19/disqus-1508786-lazyload-intersectionobserver-46-2.0.x.patch"
+            },
             "drupal/gutenberg": {
                 "Gutenberg content loads admin-type libraries.": "patches/3327698.patch"
+            },
+            "drupal/tome": {
+                "Find relative URLs in compiled CSS": "patches/3331190-2.patch"
             }
         },
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68c57cddd4bd790451a040c441346a39",
+    "content-hash": "f3cfb3fd6013ee7ca4280b37127f86cf",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/patches/3331190-2.patch
+++ b/patches/3331190-2.patch
@@ -1,0 +1,25 @@
+From dabf06bddfa6e5d54164c68bc90f753a4c4a3686 Mon Sep 17 00:00:00 2001
+From: David Pagini <davidpagini+drupal@gmail.com>
+Date: Thu, 5 Jan 2023 16:32:09 -0500
+Subject: [PATCH] Relative URL fix.
+
+---
+ modules/tome_static/src/StaticGenerator.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/modules/tome_static/src/StaticGenerator.php b/modules/tome_static/src/StaticGenerator.php
+index b88b167..f493656 100644
+--- a/modules/tome_static/src/StaticGenerator.php
++++ b/modules/tome_static/src/StaticGenerator.php
+@@ -365,7 +365,7 @@ class StaticGenerator implements StaticGeneratorInterface {
+   protected function getRealPaths(array $paths, $root) {
+     $root_dir = dirname($this->sanitizePath($root));
+     foreach ($paths as &$path) {
+-      if (strpos($path, '../') !== FALSE) {
++      if (strpos($path, '../') === 0) {
+         $path = $this->joinPaths($root_dir, $path);
+       }
+     }
+-- 
+GitLab
+


### PR DESCRIPTION
https://www.drupal.org/project/tome/issues/3331190#comment-14855415

Tome is not properly downloading/exporting the Olivero font files due to CSS aggregation. I tweaked the static generator to fix this and am pushing this patch up for testing/deployment.