### PR TITLE
Tome: removing a few extra pages.

### DIFF
--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -771,4 +771,7 @@ $settings['tome_static_path_exclude'] = [
   '/user/*',
   '/admin',
   '/admin/*',
+  // Ignore /node & /taxonomy paths to use friendly paths instead.
+  '/node/*',
+  '/taxonomy/*',
 ];


### PR DESCRIPTION
Removes canonical `taxonomy/*` URLs and `node/*` URLs.