### PR TITLE
Tome: Fix tome_static_path_exclude setting.

### DIFF
--- a/config/default/views.view.taxonomy_term.yml
+++ b/config/default/views.view.taxonomy_term.yml
@@ -56,7 +56,7 @@ display:
       access:
         type: perm
         options:
-          perm: 'access content'
+          perm: 'administer site configuration'
       cache:
         type: tag
         options: {  }
@@ -306,7 +306,10 @@ display:
       query:
         type: views_query
         options: {  }
-      display_extenders: {  }
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
       path: taxonomy/term/%
     cache_metadata:
       max-age: -1

--- a/docroot/sites/default/settings.php
+++ b/docroot/sites/default/settings.php
@@ -767,11 +767,13 @@ $settings['migrate_node_migrate_type_classic'] = FALSE;
  * Tome settings.
  */
 $settings['tome_static_path_exclude'] = [
+  # Non-canonical path for the homepage view.
+  '/node',
+  # Don't show any user pages.
   '/user',
-  '/user/*',
-  '/admin',
-  '/admin/*',
-  // Ignore /node & /taxonomy paths to use friendly paths instead.
-  '/node/*',
-  '/taxonomy/*',
+  '_entity:user:en:0',
+  '_entity:user:en:1',
+  '_entity:user:en:2',
+  # Other entries.
+  '/disqus/closewindow',
 ];


### PR DESCRIPTION
Turns out this `tome_static_path_exclude` setting does not take wildcard paths. See example in Tome module (test). In addition, I don't want the feeds exported, so I am changing that VIEW to not be permissioned for the anonymous user.

Not entirely sure what the `/disqus/closewindow` does, but going to exclude it for now.