### PR TITLE
Custom CSP module for Tome.

### DIFF
--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -36,6 +36,7 @@ module:
   token: 0
   tome: 0
   tome_base: 0
+  tome_csp: 0
   tome_static: 0
   tome_sync: 0
   toolbar: 0

--- a/config/default/metatag.metatag_defaults.global.yml
+++ b/config/default/metatag.metatag_defaults.global.yml
@@ -8,4 +8,5 @@ id: global
 label: Global
 tags:
   canonical_url: '[current-page:url]'
+  csp: 'frame-src disqus.com *.disqus.com;'
   title: '[current-page:title] | [site:name]'

--- a/docroot/modules/custom/tome_csp/config/schema/tome_csp.metatag_tag.schema.yml
+++ b/docroot/modules/custom/tome_csp/config/schema/tome_csp.metatag_tag.schema.yml
@@ -1,0 +1,3 @@
+metatag.metatag_tag.csp:
+  type: label
+  label: 'Content security policy'

--- a/docroot/modules/custom/tome_csp/src/Plugin/metatag/Tag/ContentSecurityPolicy.php
+++ b/docroot/modules/custom/tome_csp/src/Plugin/metatag/Tag/ContentSecurityPolicy.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Drupal\tome_csp\Plugin\metatag\Tag;
+
+use Drupal\metatag\Plugin\metatag\Tag\MetaHttpEquivBase;
+
+/**
+ * Content security policy as a metatag plugin.
+ *
+ * @MetatagTag(
+ *   id = "csp",
+ *   label = @Translation("Content security policy"),
+ *   description = @Translation("Provide a custom content security policy as a string. Useful for a static site where headers cannot be controlled."),
+ *   name = "Content-Security-Policy",
+ *   group = "advanced",
+ *   weight = 500,
+ *   type = "string",
+ *   secure = FALSE,
+ *   multiple = FALSE
+ * )
+ */
+class ContentSecurityPolicy extends MetaHttpEquivBase {
+  // Nothing here yet. Just a placeholder class for a plugin.
+}

--- a/docroot/modules/custom/tome_csp/tome_csp.info.yml
+++ b/docroot/modules/custom/tome_csp/tome_csp.info.yml
@@ -1,0 +1,7 @@
+name: 'Tome CSP'
+type: module
+description: 'Provide a metatag plugin.'
+core_version_requirement: ^9 || ^10
+package: Tome
+dependencies:
+  - metatag:metatag


### PR DESCRIPTION
Creating a custom module that adds a `metatag` Tag plugin, installs the module, and sets the value. 

I'm using a SUPER SIMPLE value here for the CSP, only setting the `frame-src` option for right now. Read some articles online about how whitelisting is not the most effective method, more of just a PITA anyways. Using `disqus` involves A LOT of different domains (advertising?), so I just want to avoid that for now.

I also didn't want to throw out this work...