### PR TITLE
Misc changes for image styles.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,7 @@ services:
   appserver:
     build:
       - composer install
+      - chmod -R 755 docroot/sites/default/files
     run:
       - drush tome:install -y && drush cr
       # Print a link to use to log in.

--- a/.lando.yml
+++ b/.lando.yml
@@ -16,11 +16,11 @@ services:
   appserver:
     build:
       - composer install
-      - chmod -R 755 docroot/sites/default/files
     run:
       - drush tome:install -y && drush cr
       # Print a link to use to log in.
       - drush uli --uid=2 --no-browser --uri=http://local.davidpagini.com
+      - chmod -R 755 docroot/sites/default/files
 proxy:
   appserver_nginx:
     - local.davidpagini.com

--- a/config/default/image.settings.yml
+++ b/config/default/image.settings.yml
@@ -1,5 +1,5 @@
 _core:
   default_config_hash: k-yDFHbqNfpe-Srg4sdCSqaosCl2D8uwyEY5esF8gEw
 preview_image: core/modules/image/sample.png
-allow_insecure_derivatives: false
+allow_insecure_derivatives: true
 suppress_itok_output: false


### PR DESCRIPTION
Not sure the `chmod` is actually doing anything, but we'll see. This is an attempt to avoid "cannot change file" type errors.

Also, this insecure derivatives setting was stopping image styles from generating locally. Not sure how/why my page was using an insecure token, but I don't really need this set correctly if using a static site generator.